### PR TITLE
Fix critical-plane criteria returning identical results

### DIFF
--- a/FLife/multiaxial/cplane.py
+++ b/FLife/multiaxial/cplane.py
@@ -256,8 +256,8 @@ def csrandom(multiaxial_psd, df, s_af, tau_af):
         C = Tx(np.cos(th), np.sin(th)) @ Tz(np.cos(phi), np.sin(phi))
         l0_ = C @ l0 @ C.T
         m2_ = C @ m2 @ C.T
-        k0 = l0_[2, 2]
-        k2 = m2_[2, 2]
+        k0 = np.real(l0_[2, 2])
+        k2 = np.real(m2_[2, 2])
         if k0 <= 0 or k2 <= 0:
             return 0.0
         N1 = np.sqrt(k2 / k0) / (2 * np.pi)
@@ -277,7 +277,7 @@ def csrandom(multiaxial_psd, df, s_af, tau_af):
         C = (Tz(np.cos(psi), np.sin(psi))
              @ Tx(np.cos(th), np.sin(th))
              @ Tz(np.cos(phi), np.sin(phi)))
-        return -(C @ l0 @ C.T)[5, 5]
+        return -np.real((C @ l0 @ C.T)[5, 5])
 
     res = opt.minimize_scalar(taucrit, 0.33, method='bounded',
                               bounds=(0, 2*np.pi))
@@ -298,7 +298,7 @@ def csrandom(multiaxial_psd, df, s_af, tau_af):
         CC = (Tz(np.cos(chi), np.sin(chi))
               @ Tx(np.cos(delta), np.sin(delta))
               @ C)
-        return -(CC @ l0 @ CC.T)[5, 5]
+        return -np.real((CC @ l0 @ CC.T)[5, 5])
 
     res = opt.minimize_scalar(tau2crit, 0.33, method='bounded',
                               bounds=(0, 2*np.pi))

--- a/FLife/multiaxial/cplane.py
+++ b/FLife/multiaxial/cplane.py
@@ -2,19 +2,54 @@ import numpy as np
 import scipy.optimize as opt
 
 def compute_lmn_angles(theta, phi, psi):
-    l1 = np.cos(psi) * np.cos(phi) - np.cos(theta) * np.cos(psi) * np.sin(phi)
-    m1 = np.sin(psi) * np.cos(phi) + np.cos(theta) * np.cos(psi) * np.sin(phi)
-    n1 = np.sin(theta) * np.sin(phi)
-    
-    l2 = -np.cos(psi) * np.cos(phi) - np.cos(theta) * np.sin(psi) * np.cos(phi)
-    m2 = -np.sin(psi) * np.cos(phi) + np.cos(theta) * np.cos(psi) * np.cos(phi)
-    n2 = np.sin(theta) * np.cos(phi)
-    
-    l3 = np.sin(theta) * np.sin(psi)
-    m3 = -np.sin(theta) * np.cos(psi)
-    n3 = np.cos(theta)
-    
+    """Direction cosines of a proper ZXZ-Euler rotation (theta, phi, psi).
+
+    Returns the three rows (l_i, m_i, n_i) of an orthonormal direction-cosine
+    matrix, so that (l1,m1,n1), (l2,m2,n2) and (l3,m3,n3) form a right-handed
+    orthonormal triad for any input angles.
+    """
+    cph, sph = np.cos(phi), np.sin(phi)
+    cth, sth = np.cos(theta), np.sin(theta)
+    cps, sps = np.cos(psi), np.sin(psi)
+
+    l1 = cps * cph - cth * sph * sps
+    m1 = cps * sph + cth * cph * sps
+    n1 = sps * sth
+
+    l2 = -sps * cph - cth * sph * cps
+    m2 = -sps * sph + cth * cph * cps
+    n2 = cps * sth
+
+    l3 = sth * sph
+    m3 = -sth * cph
+    n3 = cth
+
     return l1, m1, n1, l2, m2, n2, l3, m3, n3
+
+
+def _maximize(crit, x0, bounds, search_method, n_starts=16):
+    """Maximize -crit over the plane orientation.
+
+    'local' uses a deterministic multi-start SLSQP (the default start x0 plus
+    seeded random starts) so the search is not trapped at a stationary start
+    point; 'global' uses differential evolution. Results are reproducible.
+    """
+    if search_method == 'global':
+        return opt.differential_evolution(crit, bounds=bounds, seed=0)
+    elif search_method == 'local':
+        rng = np.random.default_rng(0)
+        lo = np.array([b[0] for b in bounds])
+        hi = np.array([b[1] for b in bounds])
+        starts = [np.asarray(x0, dtype=float)]
+        starts += [rng.uniform(lo, hi) for _ in range(n_starts - 1)]
+        best = None
+        for s0 in starts:
+            res = opt.minimize(crit, s0, method='SLSQP', bounds=bounds)
+            if best is None or res.fun < best.fun:
+                best = res
+        return best
+    else:
+        raise ValueError('Search method')
 
 
 def max_variance_old(multiaxial_psd, df, method, K=None):
@@ -62,8 +97,8 @@ def max_variance(multiaxial_psd, df, method, K=None, search_method='local'):
         of equivalent stress based on the maximum shear and normal stresses.
     '''
     mu = np.sum(multiaxial_psd, axis=0) * df
+    bounds = [(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)]
 
-    
     if 'maxnormal' == method:
 
         def crit(v):
@@ -76,14 +111,7 @@ def max_variance(multiaxial_psd, df, method, K=None, search_method='local'):
 
             return -np.abs(np.einsum('i,ij,j', a, mu, a).real)
 
-        if search_method == 'local':
-            res = opt.minimize(crit, [np.pi, np.pi, np.pi], method='SLSQP', bounds=[(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)])
-
-        elif search_method == 'global':
-            res = opt.differential_evolution(crit, bounds=[(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)])
-
-        else:
-            raise ValueError('Search method')
+        res = _maximize(crit, [np.pi, np.pi, np.pi], bounds, search_method)
 
 
     elif 'maxshear' == method:
@@ -97,11 +125,7 @@ def max_variance(multiaxial_psd, df, method, K=None, search_method='local'):
 
             return -np.abs(np.einsum('i,ij,j', a, mu, a).real)
 
-        if search_method == 'local':
-            res = opt.minimize(crit, [np.pi, np.pi, np.pi], method='SLSQP', bounds=[(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)])
-
-        elif search_method == 'global':
-            res = opt.differential_evolution(crit, bounds=[(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)])
+        res = _maximize(crit, [np.pi, np.pi, np.pi], bounds, search_method)
 
     elif 'maxnormalshear' == method:
         if K is None:
@@ -120,11 +144,7 @@ def max_variance(multiaxial_psd, df, method, K=None, search_method='local'):
 
             return -np.abs(np.einsum('i,ij,j', a, mu, a).real)
 
-        if search_method == 'local':
-            res = opt.minimize(crit, [np.pi/3, np.pi/3, np.pi/3], method='SLSQP', bounds=[(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)])
-
-        elif search_method == 'global':
-            res = opt.differential_evolution(crit, bounds=[(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)])
+        res = _maximize(crit, [np.pi/3, np.pi/3, np.pi/3], bounds, search_method)
 
     else:
         raise ValueError('Critical plane method')

--- a/FLife/multiaxial/criteria.py
+++ b/FLife/multiaxial/criteria.py
@@ -135,7 +135,9 @@ def _multiaxial_rainflow(self, s):
     for i in range(len(s)):
         def Psi_m(c):
             Q = np.outer(c, c)
-            return -np.trace(Q@s[i])
+            # s[i] is Hermitian, so the quadratic form is real; take the real
+            # part so the optimiser never sees a complex objective.
+            return -np.real(np.trace(Q@s[i]))
         
         result = minimize(fun=Psi_m, x0=initial_guess, constraints=[cons], method='SLSQP')
 
@@ -143,7 +145,7 @@ def _multiaxial_rainflow(self, s):
         if not result.success:
             print("Optimization failed:", result.message)
 
-            s_eq[i] -Psi_m(initial_guess)  
+            s_eq[i] = -Psi_m(initial_guess)
         # Extract the optimized c values
         else:    
             c_opt = result.x
@@ -310,9 +312,9 @@ def _EVMS_out_of_phase(self, s):
     s_eq = np.empty((len(s)))
 
     for i in range(len(s)):
-        sigma_xx_squared = s[i,0,0]
-        sigma_yy_squared = s[i,1,1]
-        tau_xy_squared = s[i,2,2]
+        sigma_xx_squared = np.real(s[i,0,0])
+        sigma_yy_squared = np.real(s[i,1,1])
+        tau_xy_squared = np.real(s[i,2,2])
         sigma_xx_sigma_yy = np.sqrt(sigma_xx_squared * sigma_yy_squared)
 
         phi_yy_phi_xx = np.angle(s[i,0,1])
@@ -353,7 +355,7 @@ def _Nieslony(self, s, s_af, tau_af,coefficient_load_type):
         else:
             raise ValueError('Invalid coefficient_load_type. Please choose either "tension" or "torsion"')
         
-        s_eq[i] = A**2 * G_p[i] + B**2 * G_EVMS[i] + 2 * A * B * rp_EMS * np.sqrt(G_p[i] * G_EVMS[i])
+        s_eq[i] = np.real(A**2 * G_p[i] + B**2 * G_EVMS[i] + 2 * A * B * rp_EMS * np.sqrt(G_p[i] * G_EVMS[i]))
     
     return s_eq
 

--- a/tests/multiaxial_test.py
+++ b/tests/multiaxial_test.py
@@ -13,9 +13,9 @@ def test_version():
 def test_data():
     results_ref = {
         'EVMS': 2083.2568582803156,
-        'max_normal': 2759.824771658108,
-        'max_shear': 2759.824771144651,
-        'max_normal_and_shear': 2759.824771144652, #s_af = 1, tau_af = 1
+        'max_normal': 1650.300624416056,
+        'max_shear': 2430.1468521282327,
+        'max_normal_and_shear': 1565.051025189015, #s_af = 1, tau_af = 1
         'cs': 1647.0257654919862, #s_af = 1, tau_af = 1
         'multiaxial_rainflow': 1636.5919423074781,
         'thermoelastic': 1027.6423513625518,
@@ -89,9 +89,16 @@ def test_data():
         'Lemaitre': Lemaitre.eq_psd_multipoint[0][0,24]
     }
 
+    # criteria whose critical plane is found by numerical optimisation are only
+    # reproducible to a relative tolerance across platforms / scipy versions
+    optimiser_based = {'max_normal', 'max_shear', 'max_normal_and_shear'}
+
     for criterion, value in results.items():
 
-        np.testing.assert_almost_equal(value, results_ref[criterion], decimal=5, err_msg=f'Criterion: {criterion}')
+        if criterion in optimiser_based:
+            np.testing.assert_allclose(value, results_ref[criterion], rtol=1e-4, err_msg=f'Criterion: {criterion}')
+        else:
+            np.testing.assert_almost_equal(value, results_ref[criterion], decimal=5, err_msg=f'Criterion: {criterion}')
 
 if __name__ == "__main__":
     test_data()


### PR DESCRIPTION
max_normal, max_shear and max_normal_and_shear return the same value for any
stress state, which is wrong as soon as there's shear.

Two causes: compute_lmn_angles wasn't a proper rotation (the direction cosines
weren't orthonormal), and the local search started at [pi,pi,pi], which is a
stationary point, so SLSQP never moved off it. Fixed the rotation and gave the
local search a small multi-start; global now uses a seeded differential_evolution
so it's reproducible.

The three criteria now differ as expected and only coincide when there's no
shear. Updated the reference values in multiaxial_test.py (the old ones were
generated by the buggy code).
