### PR TITLE
Test readme examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ Here is a simple example on how to use the code:
 
     import FLife
     import numpy as np
+    import matplotlib.pyplot as plt
 
 
     dt = 1e-4
@@ -243,7 +244,7 @@ Vibration-fatigue life can be compared to rainflow method. When Rainflow class i
     
     seed = 111
     rg =  np.random.default_rng(seed)
-    rf1 = FLife.Rainflow(sd T=100, fs=1e3) # time history is generated and assigned to parameter SpectralData.data
+    rf1 = FLife.Rainflow(sd, T=100, fs=1e3) # time history is generated and assigned to parameter SpectralData.data
     rf2 = FLife.Rainflow(sd, T=100, fs =1e3,  rg=rg) # time history is generated and assigned to parameter SpectralData.data, signal phase is defined by random generator
     rf_life_3pt = rf2.get_life(C, k, algorithm='three-point')
     rf_life_4pt = rf2.get_life(C, k, algorithm='four-point', nr_load_classes=1024) 

--- a/docs/source/FLife.rst
+++ b/docs/source/FLife.rst
@@ -50,6 +50,7 @@ Here is a simple example on how to use the code:
 
     import FLife
     import numpy as np
+    import matplotlib.pyplot as plt
 
 
     dt = 1e-4
@@ -227,7 +228,7 @@ Vibration-fatigue life can be compared to rainflow method. When Rainflow class i
     
     seed = 111
     rg =  np.random.default_rng(seed)
-    rf1 = FLife.Rainflow(sd T=100, fs=1e3) # time history is generated and assigned to parameter SpectralData.data
+    rf1 = FLife.Rainflow(sd, T=100, fs=1e3) # time history is generated and assigned to parameter SpectralData.data
     rf2 = FLife.Rainflow(sd, T=100, fs =1e3,  rg=rg) # time history is generated and assigned to parameter SpectralData.data, signal phase is defined by random generator
     rf_life_3pt = rf2.get_life(C, k, algorithm='three-point')
     rf_life_4pt = rf2.get_life(C, k, algorithm='four-point', nr_load_classes=1024) 

--- a/tests/multiaxial_test.py
+++ b/tests/multiaxial_test.py
@@ -27,12 +27,13 @@ def test_data():
     }
 
     #test_PSD
-    test_PSD = np.load('data/test_multiaxial_PSD_3D.npy')
-    test_PSD_biaxial = np.load('data/test_multiaxial_PSD_2D.npy')
+    data_dir = os.path.join(my_path, '..', 'data')
+    test_PSD = np.load(os.path.join(data_dir, 'test_multiaxial_PSD_3D.npy'))
+    test_PSD_biaxial = np.load(os.path.join(data_dir, 'test_multiaxial_PSD_2D.npy'))
 
     #Amplitude spectrum inputs
-    test_amplitude_spectrum_2D = np.load('data/test_multiaxial_amplitude_spectrum_2D.npy')
-    test_amplitude_spectrum_3D = np.load('data/test_multiaxial_amplitude_spectrum_3D.npy')
+    test_amplitude_spectrum_2D = np.load(os.path.join(data_dir, 'test_multiaxial_amplitude_spectrum_2D.npy'))
+    test_amplitude_spectrum_3D = np.load(os.path.join(data_dir, 'test_multiaxial_amplitude_spectrum_3D.npy'))
 
     freq=np.arange(0,240,3)
     freq[0] = 1e-3

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -39,7 +39,7 @@ def test_data():
         'Huang Moan': 1439.603712
     }
 
-    data = np.load(os.path.join('./data/m1.npy'))
+    data = np.load(os.path.join(my_path, '..', 'data', 'm1.npy'))
 
     t= data[::2]
     x = data[1::2]

--- a/tests/test_doc_examples.py
+++ b/tests/test_doc_examples.py
@@ -1,11 +1,12 @@
 """
-Run the Python examples embedded in README.rst, so that documentation
-examples cannot silently break on upgrades (issue #9).
+Run the Python examples embedded in the README and the documentation, so that
+they cannot silently break on upgrades (issue #9).
 
-Every ``.. code-block:: python`` in README.rst is extracted and executed in
-order, sharing a single namespace (later snippets build on earlier ones, just
-as a reader would run them top to bottom). Blocks that require the interactive
-GUI cannot run on a headless CI and are skipped.
+Every ``.. code-block:: python`` in each documentation file is extracted and
+executed in order, sharing a single namespace per file (later snippets build on
+earlier ones, just as a reader would run them top to bottom). Blocks that
+require the interactive GUI cannot run on a headless CI and are skipped, but are
+still syntax-checked.
 
 The test only checks that the examples *run*; it does not assert numerical
 results (the first example uses an unseeded random signal).
@@ -20,10 +21,15 @@ import matplotlib.pyplot as plt
 import pytest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-README = os.path.join(ROOT, "README.rst")
 
-# A block that contains any of these needs the interactive GUI / a display and
-# is skipped on a headless test runner.
+# Documentation files that contain runnable examples.
+DOC_FILES = [
+    "README.rst",
+    os.path.join("docs", "source", "FLife.rst"),
+]
+
+# A block containing any of these needs the interactive GUI / a display and is
+# skipped on a headless test runner (but still syntax-checked).
 _GUI_MARKERS = ("'GUI'", '"GUI"', "SpectralData()", "pick_point", "set_mesh")
 
 
@@ -63,9 +69,11 @@ def _testable(code):
     return not any(marker in code for marker in _GUI_MARKERS)
 
 
-def test_readme_examples():
-    blocks = _python_blocks(README)
-    assert blocks, "no '.. code-block:: python' blocks found in README.rst"
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_doc_examples(doc):
+    path = os.path.join(ROOT, doc)
+    blocks = _python_blocks(path)
+    assert blocks, f"no '.. code-block:: python' blocks found in {doc}"
 
     ns = {}
     plt.show = lambda *a, **k: None      # never block on a figure
@@ -75,10 +83,10 @@ def test_readme_examples():
         for lineno, code in blocks:
             # Syntax-check every block, including interactive ones we cannot run.
             try:
-                compiled = compile(code, f"README.rst:{lineno}", "exec")
+                compiled = compile(code, f"{doc}:{lineno}", "exec")
             except SyntaxError as exc:
                 raise AssertionError(
-                    f"README example starting at line {lineno} has a syntax error: "
+                    f"{doc} example starting at line {lineno} has a syntax error: "
                     f"{exc}\n--- block ---\n{code}\n-------------"
                 ) from exc
             # Only execute the non-interactive (non-GUI) blocks.
@@ -88,7 +96,7 @@ def test_readme_examples():
                 exec(compiled, ns)
             except Exception as exc:     # noqa: BLE001 - report which block broke
                 raise AssertionError(
-                    f"README example starting at line {lineno} failed: "
+                    f"{doc} example starting at line {lineno} failed: "
                     f"{type(exc).__name__}: {exc}\n--- block ---\n{code}\n-------------"
                 ) from exc
             finally:
@@ -98,5 +106,6 @@ def test_readme_examples():
 
 
 if __name__ == "__main__":
-    test_readme_examples()
-    print("README examples ran OK")
+    for _doc in DOC_FILES:
+        test_doc_examples(_doc)
+    print("Documentation examples ran OK")

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,0 +1,102 @@
+"""
+Run the Python examples embedded in README.rst, so that documentation
+examples cannot silently break on upgrades (issue #9).
+
+Every ``.. code-block:: python`` in README.rst is extracted and executed in
+order, sharing a single namespace (later snippets build on earlier ones, just
+as a reader would run them top to bottom). Blocks that require the interactive
+GUI cannot run on a headless CI and are skipped.
+
+The test only checks that the examples *run*; it does not assert numerical
+results (the first example uses an unseeded random signal).
+"""
+import os
+import re
+
+import matplotlib
+matplotlib.use("Agg")          # headless: no window, plt.show() is a no-op
+import matplotlib.pyplot as plt
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+README = os.path.join(ROOT, "README.rst")
+
+# A block that contains any of these needs the interactive GUI / a display and
+# is skipped on a headless test runner.
+_GUI_MARKERS = ("'GUI'", '"GUI"', "SpectralData()", "pick_point", "set_mesh")
+
+
+def _python_blocks(rst_path):
+    """Return [(lineno, code), ...] for each '.. code-block:: python' block."""
+    with open(rst_path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+
+    blocks, i, n = [], 0, len(lines)
+    directive = re.compile(r"^\s*\.\.\s+code-block::\s+python\s*$")
+    while i < n:
+        if directive.match(lines[i]):
+            j = i + 1
+            while j < n and lines[j].strip() == "":      # skip blank lines
+                j += 1
+            if j >= n:
+                break
+            indent = len(lines[j]) - len(lines[j].lstrip())
+            body, first = [], j
+            while j < n:
+                if lines[j].strip() == "":
+                    body.append("")
+                    j += 1
+                    continue
+                if len(lines[j]) - len(lines[j].lstrip()) < indent:
+                    break
+                body.append(lines[j][indent:])
+                j += 1
+            blocks.append((first + 1, "\n".join(body).rstrip()))
+            i = j
+        else:
+            i += 1
+    return blocks
+
+
+def _testable(code):
+    return not any(marker in code for marker in _GUI_MARKERS)
+
+
+def test_readme_examples():
+    blocks = _python_blocks(README)
+    assert blocks, "no '.. code-block:: python' blocks found in README.rst"
+
+    ns = {}
+    plt.show = lambda *a, **k: None      # never block on a figure
+    cwd = os.getcwd()
+    os.chdir(ROOT)                       # so np.load('data/...') resolves
+    try:
+        for lineno, code in blocks:
+            # Syntax-check every block, including interactive ones we cannot run.
+            try:
+                compiled = compile(code, f"README.rst:{lineno}", "exec")
+            except SyntaxError as exc:
+                raise AssertionError(
+                    f"README example starting at line {lineno} has a syntax error: "
+                    f"{exc}\n--- block ---\n{code}\n-------------"
+                ) from exc
+            # Only execute the non-interactive (non-GUI) blocks.
+            if not _testable(code):
+                continue
+            try:
+                exec(compiled, ns)
+            except Exception as exc:     # noqa: BLE001 - report which block broke
+                raise AssertionError(
+                    f"README example starting at line {lineno} failed: "
+                    f"{type(exc).__name__}: {exc}\n--- block ---\n{code}\n-------------"
+                ) from exc
+            finally:
+                plt.close("all")
+    finally:
+        os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    test_readme_examples()
+    print("README examples ran OK")


### PR DESCRIPTION
 Closes #9.

Adds a test that runs the Python examples from README.rst and docs/source/FLife.rst, so the docs examples can't break unnoticed on upgrades. GUI examples are syntax-checked only; the rest are executed.

Fixed two broken examples found this way (both files):
- missing `import matplotlib.pyplot as plt`
- `FLife.Rainflow(sd T=100, ...)` -> `FLife.Rainflow(sd, T=100, ...)`

Also load the test data relative to the test file, so the tests pass from any directory.