### PR TITLE
Make the Carpinteri-Spagnoli plane search scale-invariant

### DIFF
--- a/FLife/multiaxial/cplane.py
+++ b/FLife/multiaxial/cplane.py
@@ -248,6 +248,18 @@ def csrandom(multiaxial_psd, df, s_af, tau_af):
     l0 = spectral_moment(f, multiaxial_psd, 0)
     m2 = spectral_moment(f, multiaxial_psd, 2)
 
+    # Normalise the moments before the plane search. The critical plane depends
+    # only on the relative stress distribution, but SLSQP uses absolute
+    # tolerances, so an objective that scales with the PSD magnitude converges to
+    # a slightly different plane at different load levels. Scaling l0 and m2 by a
+    # common factor keeps the objective O(1) and leaves both the plane and the
+    # moment ratio in N1 unchanged. The equivalent stress is computed later in
+    # _cs from the unscaled stress.
+    scale = np.real(np.trace(l0))
+    if scale > 0:
+        l0 = l0 / scale
+        m2 = m2 / scale
+
     # Step 2: Find 1-hat direction (phi, theta).
     # Maximize Davenport expected extreme of sigma_z at [2,2].
     # C = Tx(theta) @ Tz(phi)  (psi=0 => Tz(psi) = I)

--- a/tests/multiaxial_test.py
+++ b/tests/multiaxial_test.py
@@ -16,7 +16,7 @@ def test_data():
         'max_normal': 1650.300624416056,
         'max_shear': 2430.1468521282327,
         'max_normal_and_shear': 1565.051025189015, #s_af = 1, tau_af = 1
-        'cs': 1647.0257654919862, #s_af = 1, tau_af = 1
+        'cs': 1647.0269200556531, #s_af = 1, tau_af = 1 (optimiser-based)
         'multiaxial_rainflow': 1636.5919423074781,
         'thermoelastic': 1027.6423513625518,
         'liwi': 2083.2568582803156,
@@ -91,7 +91,7 @@ def test_data():
 
     # criteria whose critical plane is found by numerical optimisation are only
     # reproducible to a relative tolerance across platforms / scipy versions
-    optimiser_based = {'max_normal', 'max_shear', 'max_normal_and_shear'}
+    optimiser_based = {'max_normal', 'max_shear', 'max_normal_and_shear', 'cs'}
 
     for criterion, value in results.items():
 


### PR DESCRIPTION
The `cs` plane search (SLSQP) uses an absolute tolerance, so its result depends on the absolute scale of the input PSD. Scaling the stress PSD by a constant, which should not change the critical-plane orientation, shifts the optimum and the equivalent stress.

This normalises the spectral moments by `trace(l0)` before the search, so the orientation is found on a scale-free problem and the result no longer depends on the input scale.

`cs` is moved to the optimiser-based relative-tolerance group in `multiaxial_test.py` (its value shifts by ~1e-6).