### PR TITLE
Fix plane-stress support in critical-plane criteria

### DIFF
--- a/FLife/multiaxial/cplane.py
+++ b/FLife/multiaxial/cplane.py
@@ -1,6 +1,27 @@
 import numpy as np
 import scipy.optimize as opt
 
+def _plane_stress_to_voigt_3d(multiaxial_psd):
+    """Promote plane-stress PSD [sx, sy, txy] to 3D Voigt [sx, sy, sz, txy, txz, tyz].
+
+    The critical-plane implementation operates on 6x6 Voigt stress transforms.
+    For documented 2D PSD input, treat the out-of-plane terms as zero and embed
+    the in-plane terms at Voigt indices [0, 1, 3].
+    """
+    if multiaxial_psd.shape[-2:] == (6, 6):
+        return multiaxial_psd
+    if multiaxial_psd.shape[-2:] != (3, 3):
+        raise ValueError('Input Error. PSD matrix should be the size of (f,6,6) for 3D stress state or (f,3,3) for 2D stress state')
+
+    psd_3d = np.zeros(multiaxial_psd.shape[:-2] + (6, 6), dtype=multiaxial_psd.dtype)
+    plane_stress_indices = [0, 1, 3]
+
+    for row_2d, row_3d in enumerate(plane_stress_indices):
+        for col_2d, col_3d in enumerate(plane_stress_indices):
+            psd_3d[..., row_3d, col_3d] = multiaxial_psd[..., row_2d, col_2d]
+
+    return psd_3d
+
 def compute_lmn_angles(theta, phi, psi):
     """Direction cosines of a proper ZXZ-Euler rotation (theta, phi, psi).
 
@@ -96,6 +117,7 @@ def max_variance(multiaxial_psd, df, method, K=None, search_method='local'):
         under multiaxial random loadings–prediction by variance
         of equivalent stress based on the maximum shear and normal stresses.
     '''
+    multiaxial_psd = _plane_stress_to_voigt_3d(multiaxial_psd)
     mu = np.sum(multiaxial_psd, axis=0) * df
     bounds = [(0, np.pi), (0, 2*np.pi), (0, 2*np.pi)]
 
@@ -244,6 +266,7 @@ def csrandom(multiaxial_psd, df, s_af, tau_af):
     domain of a critical plane-based multiaxial fatigue criterion,
     Int J Fat, 2014
     '''
+    multiaxial_psd = _plane_stress_to_voigt_3d(multiaxial_psd)
     f = np.arange(0, multiaxial_psd.shape[0] * df, df)
     l0 = spectral_moment(f, multiaxial_psd, 0)
     m2 = spectral_moment(f, multiaxial_psd, 2)

--- a/FLife/multiaxial/criteria.py
+++ b/FLife/multiaxial/criteria.py
@@ -6,6 +6,7 @@ def _max_normal(self, s, search_method):
     """
     Internal function for calculating equivalent stress at one node.
     """
+    s = cplane._plane_stress_to_voigt_3d(s)
     
     freq = self.multiaxial_psd[1]
     df = freq[1] - freq[0]
@@ -23,6 +24,7 @@ def _max_shear(self, s, search_method):
     """
     Internal function for calculating equivalent stress at one node.
     """
+    s = cplane._plane_stress_to_voigt_3d(s)
     
     freq = self.multiaxial_psd[1]
     df = freq[1] - freq[0]
@@ -40,6 +42,7 @@ def _max_normal_and_shear(self, s, s_af, tau_af, search_method='local'):
     """
     Internal function for calculating equivalent stress at one node.
     """
+    s = cplane._plane_stress_to_voigt_3d(s)
     
     freq = self.multiaxial_psd[1]
     df = freq[1] - freq[0]
@@ -92,6 +95,7 @@ def _cs(self, s, s_af, tau_af):
     """
     Internal function for calculating equivalent stress at one node.
     """
+    s = cplane._plane_stress_to_voigt_3d(s)
     
     freq = self.multiaxial_psd[1]
     df = freq[1] - freq[0]
@@ -329,6 +333,7 @@ def _Nieslony(self, s, s_af, tau_af,coefficient_load_type):
     """
     Internal function for calculating equivalent stress at one node.
     """
+    s = cplane._plane_stress_to_voigt_3d(s)
 
     G_p = 1/9*_thermoelastic(self,s)
     G_EVMS = _EVMS(self,s)

--- a/tests/multiaxial_test.py
+++ b/tests/multiaxial_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import sys, os
+import pytest
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + '/../')
 import FLife
@@ -100,6 +101,59 @@ def test_data():
             np.testing.assert_allclose(value, results_ref[criterion], rtol=1e-4, err_msg=f'Criterion: {criterion}')
         else:
             np.testing.assert_almost_equal(value, results_ref[criterion], decimal=5, err_msg=f'Criterion: {criterion}')
+
+
+def _plane_stress_psd_to_voigt_3d(psd_2d):
+    """Embed plane-stress PSD [sx, sy, txy] into 3D Voigt [sx, sy, sz, txy, txz, tyz]."""
+    psd_3d = np.zeros(psd_2d.shape[:-2] + (6, 6), dtype=psd_2d.dtype)
+    plane_stress_indices = [0, 1, 3]
+
+    for row_2d, row_3d in enumerate(plane_stress_indices):
+        for col_2d, col_3d in enumerate(plane_stress_indices):
+            psd_3d[..., row_3d, col_3d] = psd_2d[..., row_2d, col_2d]
+
+    return psd_3d
+
+
+def _run_psd_criterion(input_dict, criterion_name, **kwargs):
+    eq_stress = FLife.EquivalentStress(input=input_dict, T=1, fs=5000)
+    getattr(eq_stress, criterion_name)(**kwargs)
+    return eq_stress.eq_psd_multipoint[0]
+
+
+def test_plane_stress_reference_psd_matches_zero_padded_3d_reference():
+    data_dir = os.path.join(my_path, '..', 'data')
+    test_psd_2d = np.load(os.path.join(data_dir, 'test_multiaxial_PSD_2D.npy'))
+    test_psd_3d = np.load(os.path.join(data_dir, 'test_multiaxial_PSD_3D.npy'))
+
+    np.testing.assert_allclose(_plane_stress_psd_to_voigt_3d(test_psd_2d), test_psd_3d)
+
+
+@pytest.mark.parametrize(
+    ('criterion_name', 'criterion_kwargs'),
+    [
+        ('max_normal', {}),
+        ('max_shear', {}),
+        ('max_normal_and_shear', {'s_af': 1, 'tau_af': 1}),
+        ('cs', {'s_af': 1, 'tau_af': 1}),
+        ('Nieslony', {'s_af': 1, 'tau_af': 1}),
+    ],
+)
+def test_plane_stress_psd_criteria_match_zero_padded_3d(criterion_name, criterion_kwargs):
+    """Plane-stress PSD input should behave like the equivalent 3D Voigt PSD with zero out-of-plane terms."""
+    data_dir = os.path.join(my_path, '..', 'data')
+    test_psd_2d = np.load(os.path.join(data_dir, 'test_multiaxial_PSD_2D.npy'))
+
+    freq=np.arange(0,240,3)
+    freq[0] = 1e-3
+
+    input_dict_psd_2d = {'PSD': test_psd_2d[331:335], 'f': freq}
+    input_dict_psd_3d = {'PSD': _plane_stress_psd_to_voigt_3d(test_psd_2d[331:335]), 'f': freq}
+
+    psd_2d_eq = _run_psd_criterion(input_dict_psd_2d, criterion_name, **criterion_kwargs)
+    psd_3d_eq = _run_psd_criterion(input_dict_psd_3d, criterion_name, **criterion_kwargs)
+
+    np.testing.assert_allclose(psd_2d_eq, psd_3d_eq, rtol=1e-6, atol=1e-8)
 
 if __name__ == "__main__":
     test_data()


### PR DESCRIPTION
## Summary

This fixes the documented 2D plane-stress PSD path for several multiaxial criteria that internally assumed 6x6 Voigt stress tensors.

The minimal fix is to embed 2D plane-stress PSD input `[sx, sy, txy]` into the existing 3D Voigt layout `[sx, sy, sz, txy, txz, tyz]` with zero out-of-plane terms, and then reuse the current 6x6 implementation.

## Problem

`EquivalentStress` documents support for PSD input with shape `(f,3,3)` for 2D stress states.

In practice, some criteria still assumed 6 stress components internally:

- `max_normal`
- `max_shear`
- `max_normal_and_shear`
- `cs`
- `Nieslony`

This caused failures for plane-stress PSD input:
- critical-plane criteria built 6-component projection vectors and applied them to `3x3` PSD matrices
- `csrandom` used `6x6` transformation matrices directly on `3x3` moments
- `Nieslony` indexed out-of-plane components that do not exist in the 2D case

## Fix

I added a small internal helper that promotes a plane-stress PSD matrix to the equivalent zero-padded 3D Voigt representation and used it only in the affected critical-plane paths.

This keeps the change localized and reuses the existing 6x6 implementation instead of introducing separate 2D critical-plane branches.

## Tests

Added regression coverage to verify that, for the affected criteria, a 2D plane-stress PSD input gives the same equivalent PSD as the corresponding 3D zero-padded Voigt PSD.

The new tests cover:

- `max_normal`
- `max_shear`
- `max_normal_and_shear`
- `cs`
- `Nieslony`

They also verify that the reference 2D test PSD matches the stored 3D reference after zero-padding.

## Validation

Ran:
- `pytest -q`
- `python -m sphinx -b html docs/source docs/build/html`

Both passed locally.